### PR TITLE
Add tmPreferences file to enable toggling of comments

### DIFF
--- a/SLS.tmPreferences
+++ b/SLS.tmPreferences
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Salt State (SLS)</string>
+	<key>uuid</key>
+	<string>CABCF90B-1B3C-43E2-BF09-3FFC271DCCD6</string>
+	<key>scope</key>
+	<string>source.sls</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string># </string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Adding this file with the settings dictionary (copied directly from the default YAML package) enables toggling of YAML comments with `ctrl+/`.