### PR TITLE
Highlight "yes" and "no" as boolean constants

### DIFF
--- a/SLS.tmLanguage
+++ b/SLS.tmLanguage
@@ -31,7 +31,7 @@
 		<!-- Highlighting of boolean constants -->
 		<dict>
 			<key>match</key>
-			<string>((-)\s*)?((([\w\/][^\:\#]*)|(\"[\w\/][^\:\#]*\")|(\'[\w\/][^\:\#]*\'))(:))?\s*(?i)((true|false)|(null|\~))(?-i)\s*(\#.*)?$</string>
+			<string>((-)\s*)?((([\w\/][^\:\#]*)|(\"[\w\/][^\:\#]*\")|(\'[\w\/][^\:\#]*\'))(:))?\s*(?i)((true|false|yes|no)|(null|\~))(?-i)\s*(\#.*)?$</string>
 			<key>name</key>
 			<string>meta.tag.yaml</string>
 			<key>captures</key>


### PR DESCRIPTION
I couldn't find this in the YAML spec, but apparently, in python, unquoted `yes` and `no` translate to booleans and should be highlighted as such. I discovered this trying to manage an sshd_config, and I was seeing `False` being output instead of `no`. Had I seen yes/no highlighted as constants I probably would've realised way earlier.

```
>>> import yaml
>>> yaml.load('foo: yes')
{'foo': True}
>>> yaml.load('foo: YES')
{'foo': True}
>>> yaml.load('foo: no')
{'foo': False}
```