### PR TITLE
jinja scope changed to jinja2

### DIFF
--- a/SLS.tmLanguage
+++ b/SLS.tmLanguage
@@ -25,7 +25,7 @@
 	<array>
 		<dict>
 			<key>include</key>
-			<string>source.jinja</string>
+			<string>source.jinja2</string>
 		</dict>
 
 		<!-- Highlighting of boolean constants -->


### PR DESCRIPTION
The original jinja2 syntax package changed sources recently: https://github.com/wbond/package_control_channel/pull/4688

This new version changes the name of the scope from "jinja" to "jinja2" [as seen here](https://github.com/kudago/jinja2-tmbundle/commit/279553bdc5dca1bf0930dc89f441c19b3a8898a3).

Currently, no jinja-related syntax in this package is working.